### PR TITLE
Reworked Setting

### DIFF
--- a/firmware/src/display_task.cpp
+++ b/firmware/src/display_task.cpp
@@ -120,7 +120,7 @@ void DisplayTask::run()
       fps_counter++;
       if (last_fps_check + 1000 < millis())
       {
-        ESP_LOGD("display_task.cpp", "Screen real FPS %d", fps_counter);
+        // ESP_LOGD("display_task.cpp", "Screen real FPS %d", fps_counter);
         fps_counter = 0;
         last_fps_check = millis();
       }


### PR DESCRIPTION
- removed the benTen loose if-then-else view that was pre-rendering sometimes when opening the settings.
- added dot-navigation menu to the setting view (if we like it we should probably abstract one layer up).
- added a view with a loading animation. (TBD: I want to sync the led so they pulse when the circle touches the edge).
- minor graphic changes.