### PR TITLE
HASS Setup Webserver Bug

### DIFF
--- a/firmware/src/onboarding_flow/onboarding_flow.cpp
+++ b/firmware/src/onboarding_flow/onboarding_flow.cpp
@@ -191,7 +191,10 @@ void OnboardingFlow::handleNavigationEvent(NavigationEvent event)
         {
         case ONBOARDING_FLOW_PAGE_STEP_HASS_1:
             current_page = ONBOARDING_FLOW_PAGE_STEP_HASS_2;
-            wifi_notifier->requestAP();
+            if (!is_wifi_ap_started) // TODO: Make it actually use ap status, isnt updated if ap turns off. Or handle in wifi_task.
+            {
+                wifi_notifier->requestAP();
+            }
 
             motor_notifier->requestUpdate(blocked_motor_config);
             break;


### PR DESCRIPTION
Fixes HASS onboarding bug where user first goes to HASS setup screen and then returns to onboarding start after AP creds are displayed. Then tries to do HASS setup again. Webserver wouldnt respond.