### PR TITLE
Fix/first state color not set

### DIFF
--- a/firmware/src/apps/light_dimmer/light_dimmer.h
+++ b/firmware/src/apps/light_dimmer/light_dimmer.h
@@ -35,11 +35,13 @@ private:
     // app state
     uint8_t app_state_mode = LIGHT_DIMMER_APP_MODE_DIMMER;
 
-    bool color_not_set = false;
+    bool color_set = true;
 
     uint16_t app_hue_position = 0;
     uint8_t current_brightness = 0;
     bool is_on = false;
 
     bool first_run = false;
+
+    uint16_t calculateAppHuePosition(uint16_t position);
 };

--- a/firmware/src/apps/light_dimmer/light_dimmer.h
+++ b/firmware/src/apps/light_dimmer/light_dimmer.h
@@ -35,6 +35,8 @@ private:
     // app state
     uint8_t app_state_mode = LIGHT_DIMMER_APP_MODE_DIMMER;
 
+    bool color_not_set = false;
+
     uint16_t app_hue_position = 0;
     uint8_t current_brightness = 0;
     bool is_on = false;


### PR DESCRIPTION
Fixed color being set to red if lights first state was off that was sent to knob, HASS doesn't keep track of light color state when off so a null value was sent to knob and we then set light color to red. Now if light is off we send null value for rgb_color wich just starts light and light starts with old color.

This prevents us from knowing what color a light is when a light is turned off at first boot of knob.