### PR TITLE
More data for init of knob in HASS.

### DIFF
--- a/firmware/src/network/mqtt_task.cpp
+++ b/firmware/src/network/mqtt_task.cpp
@@ -325,6 +325,18 @@ bool MqttTask::init()
     cJSON_AddStringToObject(json, "id", hexbuffer_);
     cJSON_AddStringToObject(json, "mac_address", WiFi.macAddress().c_str());
 
+    cJSON *data = cJSON_CreateObject();
+
+    cJSON_AddStringToObject(data, "model", MODEL);
+#ifdef RELEASE_VERSION
+    cJSON_AddStringToObject(data, "version", RELEASE_VERSION);
+#else
+    cJSON_AddStringToObject(data, "firmware_version", "DEV");
+#endif
+    cJSON_AddStringToObject(data, "manufacturer", "Seedlabs");
+
+    cJSON_AddItemToObject(json, "data", data);
+
     unacknowledged_ids.insert(std::make_pair(hexbuffer_, "init"));
 
     char *init_string = cJSON_PrintUnformatted(json);

--- a/platformio.ini
+++ b/platformio.ini
@@ -133,7 +133,7 @@ build_flags =
     -D SOFT_RESET_SECONDS=5
     -D HARD_RESET_SECONDS=15
 
-    -D MODEL='"SeedLabs DevKit v0.1"'
+    -D MODEL='"SmartKnob DevKit v0.1"'
 
 
 [env:seedlabs_devkit_inverted_display]

--- a/platformio.ini
+++ b/platformio.ini
@@ -133,6 +133,8 @@ build_flags =
     -D SOFT_RESET_SECONDS=5
     -D HARD_RESET_SECONDS=15
 
+    -D MODEL='"SeedLabs DevKit v0.1"'
+
 
 [env:seedlabs_devkit_inverted_display]
 build_flags = 


### PR DESCRIPTION
Added model version to platformio.ini and data object to init mqtt payload containing, model, firmware_version and manufacturer information.