### PR TITLE
Better release workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,9 +53,15 @@ jobs:
       run: |
         pio run \
           -e seedlabs_devkit_github_action_release
+    - name: Zip Firmware
+      run: |
+        cd .pio/build/seedlabs_devkit_github_action_release/
+        cp ./firmware.bin "${RELEASE_VERSION}.bin"
+        cp ~/.pio/packages/framework-arduinoespressif32/tools/sdk/esp32s3/bin/bootloader_dio_80m.elf .pio/build/seedlabs_devkit_github_action_release/bootloader_dio_80m.elf
+        zip -r "${RELEASE_VERSION}.zip" ./ ~/.pio/build/seedlabs_devkit_github_action_release/bootloader_dio_80m.elf
     
     - name: Upload Release Assets
       uses: AButler/upload-release-assets@v3.0
       with:
-        files: ".pio/build/seedlabs_devkit_github_action_release/firmware.bin"
+        files: ".pio/build/seedlabs_devkit_github_action_release/${RELEASE_VERSION}.bin;.pio/build/seedlabs_devkit_github_action_release/${RELEASE_VERSION}.zip"
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         cd .pio/build/seedlabs_devkit_github_action_release/
         cp ./firmware.bin "${RELEASE_VERSION}.bin"
-        cp ~/.pio/packages/framework-arduinoespressif32/tools/sdk/esp32s3/bin/bootloader_dio_80m.elf .pio/build/seedlabs_devkit_github_action_release/bootloader_dio_80m.elf
+        cp ~/.platformio/packages/framework-arduinoespressif32/tools/sdk/esp32s3/bin/bootloader_dio_80m.elf .pio/build/seedlabs_devkit_github_action_release/bootloader_dio_80m.elf
         zip -r "${RELEASE_VERSION}.zip" ./ ~/.pio/build/seedlabs_devkit_github_action_release/bootloader_dio_80m.elf
     
     - name: Upload Release Assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,12 +56,12 @@ jobs:
     - name: Zip Firmware
       run: |
         cd .pio/build/seedlabs_devkit_github_action_release/
-        cp ./firmware.bin "${RELEASE_VERSION}.bin"
+        cp ./firmware.bin "firmware_${RELEASE_VERSION}.bin"
         cp ~/.platformio/packages/framework-arduinoespressif32/tools/sdk/esp32s3/bin/bootloader_dio_80m.elf ./bootloader_dio_80m.elf
         zip -r "${RELEASE_VERSION}.zip" ./ ~/.pio/build/seedlabs_devkit_github_action_release/bootloader_dio_80m.elf
     
     - name: Upload Release Assets
       uses: AButler/upload-release-assets@v3.0
       with:
-        files: ".pio/build/seedlabs_devkit_github_action_release/${RELEASE_VERSION}.bin;.pio/build/seedlabs_devkit_github_action_release/${RELEASE_VERSION}.zip"
+        files: ".pio/build/seedlabs_devkit_github_action_release/firmware_*.bin;.pio/build/seedlabs_devkit_github_action_release/*.zip"
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
         cd .pio/build/seedlabs_devkit_github_action_release/
         cp ./firmware.bin "firmware_${RELEASE_VERSION}.bin"
         cp ~/.platformio/packages/framework-arduinoespressif32/tools/sdk/esp32s3/bin/bootloader_dio_80m.elf ./bootloader_dio_80m.elf
-        zip -r "${RELEASE_VERSION}.zip" ./ ~/.pio/build/seedlabs_devkit_github_action_release/bootloader_dio_80m.elf
+        zip -r "${RELEASE_VERSION}.zip" ./
     
     - name: Upload Release Assets
       uses: AButler/upload-release-assets@v3.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
         cd .pio/build/seedlabs_devkit_github_action_release/
         cp ./firmware.bin "../firmware_${RELEASE_VERSION}.bin"
         cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin ./boot_app0.bin
-        zip -r "${RELEASE_VERSION}.zip" -i "*.bin" "*.elf"
+        zip -r "${RELEASE_VERSION}.zip" ./*.bin ./*.elf
     
     - name: Upload Release Assets
       uses: AButler/upload-release-assets@v3.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,12 +56,12 @@ jobs:
     - name: Zip Firmware
       run: |
         cd .pio/build/seedlabs_devkit_github_action_release/
-        cp ./firmware.bin "firmware_${RELEASE_VERSION}.bin"
-        cp ~/.platformio/packages/framework-arduinoespressif32/tools/sdk/esp32s3/bin/bootloader_dio_80m.elf ./bootloader_dio_80m.elf
-        zip -r "${RELEASE_VERSION}.zip" ./
+        cp ./firmware.bin "../firmware_${RELEASE_VERSION}.bin"
+        cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin ./boot_app0.bin
+        zip -r "${RELEASE_VERSION}.zip" -i "*.bin" "*.elf"
     
     - name: Upload Release Assets
       uses: AButler/upload-release-assets@v3.0
       with:
-        files: ".pio/build/seedlabs_devkit_github_action_release/firmware_*.bin;.pio/build/seedlabs_devkit_github_action_release/*.zip"
+        files: ".pio/build/firmware_*.bin;.pio/build/seedlabs_devkit_github_action_release/*.zip"
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         cd .pio/build/seedlabs_devkit_github_action_release/
         cp ./firmware.bin "${RELEASE_VERSION}.bin"
-        cp ~/.platformio/packages/framework-arduinoespressif32/tools/sdk/esp32s3/bin/bootloader_dio_80m.elf .pio/build/seedlabs_devkit_github_action_release/bootloader_dio_80m.elf
+        cp ~/.platformio/packages/framework-arduinoespressif32/tools/sdk/esp32s3/bin/bootloader_dio_80m.elf ./bootloader_dio_80m.elf
         zip -r "${RELEASE_VERSION}.zip" ./ ~/.pio/build/seedlabs_devkit_github_action_release/bootloader_dio_80m.elf
     
     - name: Upload Release Assets


### PR DESCRIPTION
Uploads a named firmware.bin file with RELEASE_VERSION.
Uploads a zip with all binaries needed to completely re flash knob.