### PR TITLE
Power down and up strain when not in use etc.

### DIFF
--- a/firmware/src/root_task.cpp
+++ b/firmware/src/root_task.cpp
@@ -559,9 +559,16 @@ void RootTask::updateHardware(AppState *app_state)
     {
         switch (latest_sensors_state_.strain.virtual_button_code)
         {
+
         case VIRTUAL_BUTTON_SHORT_PRESSED:
             if (last_strain_pressed_played_ != VIRTUAL_BUTTON_SHORT_PRESSED)
             {
+                app_state->screen_state.has_been_engaged = true;
+                if (app_state->screen_state.awake_until < millis() + 8000)
+                {
+                    app_state->screen_state.awake_until = millis() + 30000; // stay awake for 4 seconds after last interaction
+                }
+
                 LOGD("Handling short press");
                 motor_task_.playHaptic(true, false);
                 last_strain_pressed_played_ = VIRTUAL_BUTTON_SHORT_PRESSED;
@@ -571,6 +578,12 @@ void RootTask::updateHardware(AppState *app_state)
         case VIRTUAL_BUTTON_LONG_PRESSED:
             if (last_strain_pressed_played_ != VIRTUAL_BUTTON_LONG_PRESSED)
             {
+                app_state->screen_state.has_been_engaged = true;
+                if (app_state->screen_state.awake_until < millis() + 8000)
+                {
+                    app_state->screen_state.awake_until = millis() + 30000; // stay awake for 4 seconds after last interaction
+                }
+
                 LOGD("Handling long press");
 
                 motor_task_.playHaptic(true, true);
@@ -656,14 +669,14 @@ void RootTask::updateHardware(AppState *app_state)
             break;
         }
 
-        if (last_strain_pressed_played_ != VIRTUAL_BUTTON_IDLE)
-        {
-            app_state->screen_state.has_been_engaged = true;
-            if (app_state->screen_state.awake_until < millis() + 8000)
-            {
-                app_state->screen_state.awake_until = millis() + 30000; // stay awake for 4 seconds after last interaction
-            }
-        }
+        // if (latest_sensors_state_.strain.virtual_button_code != VIRTUAL_BUTTON_IDLE)
+        // {
+        //     app_state->screen_state.has_been_engaged = true;
+        //     if (app_state->screen_state.awake_until < millis() + 8000)
+        //     {
+        //         app_state->screen_state.awake_until = millis() + 30000; // stay awake for 4 seconds after last interaction
+        //     }
+        // }
     }
 
 #endif

--- a/firmware/src/root_task.cpp
+++ b/firmware/src/root_task.cpp
@@ -402,7 +402,7 @@ void RootTask::run()
                 app_state.screen_state.has_been_engaged = true;
                 if (app_state.screen_state.awake_until < millis() + 2000)
                 {
-                    app_state.screen_state.awake_until = millis() + 4000; // stay awake for 4 seconds after last interaction
+                    app_state.screen_state.awake_until = millis() + 8000; // stay awake for 4 seconds after last interaction
                 }
             }
         }
@@ -440,7 +440,7 @@ void RootTask::run()
                     app_state.screen_state.has_been_engaged = true;
                     if (app_state.screen_state.awake_until < millis() + 2000)
                     {
-                        app_state.screen_state.awake_until = millis() + 10000; // stay awake for 4 seconds after last interaction
+                        app_state.screen_state.awake_until = millis() + 30000; // stay awake for 4 seconds after last interaction
                     }
                 }
             }
@@ -529,7 +529,7 @@ void RootTask::run()
         motor_notifier.loopTick();
         os_config_notifier_.loopTick();
 
-        updateHardware(app_state);
+        updateHardware(&app_state);
 
         if (app_state.screen_state.has_been_engaged == true)
         {
@@ -550,7 +550,7 @@ void RootTask::run()
     }
 }
 
-void RootTask::updateHardware(AppState app_state)
+void RootTask::updateHardware(AppState *app_state)
 {
     static bool pressed;
 #if SK_STRAIN
@@ -658,10 +658,10 @@ void RootTask::updateHardware(AppState app_state)
 
         if (last_strain_pressed_played_ != VIRTUAL_BUTTON_IDLE)
         {
-            app_state.screen_state.has_been_engaged = true;
-            if (app_state.screen_state.awake_until < millis() + 8000)
+            app_state->screen_state.has_been_engaged = true;
+            if (app_state->screen_state.awake_until < millis() + 8000)
             {
-                app_state.screen_state.awake_until = millis() + 10000; // stay awake for 4 seconds after last interaction
+                app_state->screen_state.awake_until = millis() + 30000; // stay awake for 4 seconds after last interaction
             }
         }
     }
@@ -671,7 +671,7 @@ void RootTask::updateHardware(AppState app_state)
     uint16_t brightness = UINT16_MAX;
 // TODO: brightness scale factor should be configurable (depends on reflectivity of surface)
 #if SK_ALS
-    brightness = app_state.screen_state.brightness;
+    brightness = app_state->screen_state.brightness;
 #endif
 
 #if SK_DISPLAY
@@ -690,7 +690,7 @@ void RootTask::updateHardware(AppState app_state)
         // if 2: led ring is fully off.
         // if 3: we have 1 led on as beacon (also refered as lighthouse in other part of the code).
 
-        if (brightness > app_state.screen_state.MIN_LCD_BRIGHTNESS)
+        if (brightness > app_state->screen_state.MIN_LCD_BRIGHTNESS)
         {
             // case 1. FADE-IN led
             effect_settings.effect_id = 4; // FADE-IN
@@ -703,7 +703,7 @@ void RootTask::updateHardware(AppState app_state)
             effect_settings.effect_main_color = (0 << 16) | (128 << 8) | 128;
             led_ring_task_->setEffect(effect_settings);
         }
-        else if (brightness == app_state.screen_state.MIN_LCD_BRIGHTNESS)
+        else if (brightness == app_state->screen_state.MIN_LCD_BRIGHTNESS)
         {
             // case 2. FADE-OUT led
             effect_settings.effect_id = 5;

--- a/firmware/src/root_task.cpp
+++ b/firmware/src/root_task.cpp
@@ -400,9 +400,9 @@ void RootTask::run()
             if (app_state.proximiti_state.RangeStatus < 3 && app_state.proximiti_state.RangeMilliMeter < 200)
             {
                 app_state.screen_state.has_been_engaged = true;
-                if (app_state.screen_state.awake_until < millis() + 2000)
+                if (app_state.screen_state.awake_until < millis() + KNOB_ENGAGED_TIMEOUT_NONE_PHYSICAL) // If half of the time of the last interaction has passed, reset allow for engage to be detected again.
                 {
-                    app_state.screen_state.awake_until = millis() + 8000; // stay awake for 4 seconds after last interaction
+                    app_state.screen_state.awake_until = millis() + KNOB_ENGAGED_TIMEOUT_NONE_PHYSICAL;
                 }
             }
         }
@@ -438,9 +438,9 @@ void RootTask::run()
                     // We set a flag on the object Screen State.
                     //  Todo: this property should be at app state and not screen state
                     app_state.screen_state.has_been_engaged = true;
-                    if (app_state.screen_state.awake_until < millis() + 2000)
+                    if (app_state.screen_state.awake_until < millis() + KNOB_ENGAGED_TIMEOUT_PHYSICAL / 2) // If half of the time of the last interaction has passed, reset allow for engage to be detected again.
                     {
-                        app_state.screen_state.awake_until = millis() + 30000; // stay awake for 4 seconds after last interaction
+                        app_state.screen_state.awake_until = millis() + KNOB_ENGAGED_TIMEOUT_PHYSICAL; // stay awake for 4 seconds after last interaction
                     }
                 }
             }
@@ -510,21 +510,7 @@ void RootTask::run()
             publishState();
         }
 
-        // // Check if the knob is awake, and if the time is expired
-        // // and set it to not engaged
-        // else
-        // {
-        //     app_state.screen_state.has_been_engaged = false;
-        //         }
-
         current_protocol_->loop();
-
-        // std::string *log_string;
-        // while (xQueueReceive(log_queue_, &log_string, 0) == pdTRUE)
-        // {
-        //     // LOGI(log_string->c_str());
-        //     delete log_string;
-        // }
 
         motor_notifier.loopTick();
         os_config_notifier_.loopTick();
@@ -564,9 +550,9 @@ void RootTask::updateHardware(AppState *app_state)
             if (last_strain_pressed_played_ != VIRTUAL_BUTTON_SHORT_PRESSED)
             {
                 app_state->screen_state.has_been_engaged = true;
-                if (app_state->screen_state.awake_until < millis() + 8000)
+                if (app_state->screen_state.awake_until < millis() + KNOB_ENGAGED_TIMEOUT_PHYSICAL / 2) // If half of the time of the last interaction has passed, reset allow for engage to be detected again.
                 {
-                    app_state->screen_state.awake_until = millis() + 30000; // stay awake for 4 seconds after last interaction
+                    app_state->screen_state.awake_until = millis() + KNOB_ENGAGED_TIMEOUT_PHYSICAL; // stay awake for 4 seconds after last interaction
                 }
 
                 LOGD("Handling short press");
@@ -579,9 +565,9 @@ void RootTask::updateHardware(AppState *app_state)
             if (last_strain_pressed_played_ != VIRTUAL_BUTTON_LONG_PRESSED)
             {
                 app_state->screen_state.has_been_engaged = true;
-                if (app_state->screen_state.awake_until < millis() + 8000)
+                if (app_state->screen_state.awake_until < millis() + KNOB_ENGAGED_TIMEOUT_PHYSICAL / 2) // If half of the time of the last interaction has passed, reset allow for engage to be detected again.
                 {
-                    app_state->screen_state.awake_until = millis() + 30000; // stay awake for 4 seconds after last interaction
+                    app_state->screen_state.awake_until = millis() + KNOB_ENGAGED_TIMEOUT_PHYSICAL; // stay awake for 4 seconds after last interaction
                 }
 
                 LOGD("Handling long press");
@@ -668,15 +654,6 @@ void RootTask::updateHardware(AppState *app_state)
             last_strain_pressed_played_ = VIRTUAL_BUTTON_IDLE;
             break;
         }
-
-        // if (latest_sensors_state_.strain.virtual_button_code != VIRTUAL_BUTTON_IDLE)
-        // {
-        //     app_state->screen_state.has_been_engaged = true;
-        //     if (app_state->screen_state.awake_until < millis() + 8000)
-        //     {
-        //         app_state->screen_state.awake_until = millis() + 30000; // stay awake for 4 seconds after last interaction
-        //     }
-        // }
     }
 
 #endif

--- a/firmware/src/root_task.h
+++ b/firmware/src/root_task.h
@@ -109,7 +109,7 @@ private:
     uint32_t last_calib_state_sent_ = 0;
 
     // void changeConfig(int8_t id);
-    void updateHardware(AppState app_state);
+    void updateHardware(AppState *app_state);
     void publishState();
     void applyConfig(PB_SmartKnobConfig config, bool from_remote);
     void publish(const AppState &state);

--- a/firmware/src/sensors/sensors_task.cpp
+++ b/firmware/src/sensors/sensors_task.cpp
@@ -99,6 +99,7 @@ void SensorsTask::run()
     unsigned long last_illumination_check_ms = 0;
 
     unsigned long log_ms = 0;
+    unsigned long log_ms_strain = 0;
 
     const uint8_t proximity_poling_rate_hz = 20;
     const uint8_t strain_poling_rate_hz = 120;
@@ -282,14 +283,15 @@ void SensorsTask::run()
             }
             else
             {
-                if (do_strain)
+                if (do_strain && millis() - log_ms_strain > 4000)
                 {
                     LOGV(PB_LogLevel_DEBUG, "Strain sensor not ready, waiting...");
+                    log_ms_strain = millis();
                 }
-                else
+                else if (millis() - log_ms_strain > 4000)
                 {
-
                     LOGV(PB_LogLevel_DEBUG, "Strain sensor is disabled. (Might be because of factory calib or its powered off because no engagement of knob)");
+                    log_ms_strain = millis();
                 }
             }
         }

--- a/firmware/src/sensors/sensors_task.cpp
+++ b/firmware/src/sensors/sensors_task.cpp
@@ -438,6 +438,20 @@ void SensorsTask::weightMeasurementCallback()
         weight_measurement_step_ = 0;
     }
 }
+
+void SensorsTask::strainPowerDown()
+{
+    LOGV(PB_LogLevel_DEBUG, "Strain sensor power down.");
+    strain.power_down();
+}
+
+void SensorsTask::strainPowerUp()
+{
+    LOGV(PB_LogLevel_DEBUG, "Strain sensor power up.");
+    strain.power_up();
+    delay(100);
+    strain.tare();
+}
 #endif
 
 void SensorsTask::addStateListener(QueueHandle_t queue)

--- a/firmware/src/sensors/sensors_task.cpp
+++ b/firmware/src/sensors/sensors_task.cpp
@@ -411,6 +411,8 @@ void SensorsTask::factoryStrainCalibrationCallback(float calibration_weight)
             {
                 LOGE("Calibrated weight is more than 10g off from the calibration weight. Restart calibration by pressing 'Y' again.");
                 delay(2000);
+                strain.set_scale(1.0f);
+                calibration_scale_ = 1.0f;
                 factory_strain_calibration_step_ = 0;
                 return;
             }

--- a/firmware/src/sensors/sensors_task.cpp
+++ b/firmware/src/sensors/sensors_task.cpp
@@ -178,7 +178,6 @@ void SensorsTask::run()
                         discarded_strain_reading_count++;
                         if (discarded_strain_reading_count > 20)
                         {
-                            LOGE("HERE!!!!!!!!!!!!!!!!!!!!!!!!!! RESET STRAIN!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
                             LOGV(PB_LogLevel_WARNING, "Resetting strain sensor. 20 consecutive readings discarded.");
                             strain.power_down();
                             delay(100);
@@ -481,7 +480,7 @@ void SensorsTask::strainPowerDown()
     }
 }
 
-void SensorsTask::strainPowerUp() // Delays caused to a perceived delay in the activation of strain.
+void SensorsTask::strainPowerUp() // Delays caused a perceived delay in the activation of strain.
 {
     if (!strain.wait_ready_timeout(10)) // Make sure sensor is off before powering up.
     {
@@ -490,11 +489,9 @@ void SensorsTask::strainPowerUp() // Delays caused to a perceived delay in the a
         strain.power_up();
         if (strain.wait_ready_timeout(100))
         {
-            // delay(25);
             strain.set_offset(0);
             strain.tare();
             last_strain_reading_raw_ = strain.get_units(10);
-            // LOGV(PB_LogLevel_DEBUG, "Strain value after power up: %f", last_strain_reading_raw_);
             strain_powered = true;
         }
         else

--- a/firmware/src/sensors/sensors_task.cpp
+++ b/firmware/src/sensors/sensors_task.cpp
@@ -449,8 +449,8 @@ void SensorsTask::strainPowerUp()
 {
     LOGV(PB_LogLevel_DEBUG, "Strain sensor power up.");
     strain.power_up();
-    delay(100);
-    strain.tare();
+    // delay(100);
+    // strain.tare();
 }
 #endif
 

--- a/firmware/src/sensors/sensors_task.cpp
+++ b/firmware/src/sensors/sensors_task.cpp
@@ -475,18 +475,17 @@ void SensorsTask::strainPowerDown()
     strain.power_down();
 }
 
-void SensorsTask::strainPowerUp()
+void SensorsTask::strainPowerUp() // Delays caused to a perceived delay in the activation of strain.
 {
     LOGV(PB_LogLevel_DEBUG, "Strain sensor power up.");
     strain.power_up();
-    delay(25);
+    // delay(25);
     strain.set_offset(0);
     strain.tare();
-    delay(100);
-    last_strain_reading_raw_ = strain.get_units(10);
-    LOGE("Strain value after power up: %f", last_strain_reading_raw_);
-    strain_powered = true;
     // delay(100);
+    last_strain_reading_raw_ = strain.get_units(10);
+    LOGV(PB_LogLevel_DEBUG, "Strain value after power up: %f", last_strain_reading_raw_);
+    strain_powered = true;
 }
 #endif
 

--- a/firmware/src/sensors/sensors_task.cpp
+++ b/firmware/src/sensors/sensors_task.cpp
@@ -57,6 +57,7 @@ void SensorsTask::run()
     strain.tare();
     delay(100);
 
+    strain_powered = true;
     raw_initial_value_ = strain.get_units(10);
 #endif
 
@@ -125,7 +126,7 @@ void SensorsTask::run()
     long last_system_temperature_check = 0;
     float last_system_temperature = 0;
 
-    bool do_strain = false;
+    uint8_t discarded_strain_reading_count = 0;
 
     while (1)
     {
@@ -152,18 +153,17 @@ void SensorsTask::run()
 #if SK_STRAIN
         if (millis() - last_strain_check_ms > 1000 / strain_poling_rate_hz)
         {
-            if (strain.wait_ready_timeout(100))
+            if (strain_powered && strain.wait_ready_timeout(100))
             {
-                if (weight_measurement_step_ != 0 || factory_strain_calibration_step_ != 0)
-                {
-                    delay(100);
-                    do_strain = false;
-                }
-
                 if (calibration_scale_ == 1.0f && strain.get_scale() == 1.0f && factory_strain_calibration_step_ == 0)
                 {
                     LOGI("Strain sensor needs Factory Calibration, press 'Y' to begin!");
                     delay(2000);
+                    do_strain = false;
+                }
+                else if (weight_measurement_step_ != 0 || factory_strain_calibration_step_ != 0)
+                {
+                    delay(100);
                     do_strain = false;
                 }
 
@@ -174,12 +174,28 @@ void SensorsTask::run()
 
                     if (abs(last_strain_reading_raw_ - strain_reading_raw) > 2000)
                     {
+                        discarded_strain_reading_count++;
+                        if (discarded_strain_reading_count > 20)
+                        {
+                            LOGE("HERE!!!!!!!!!!!!!!!!!!!!!!!!!! RESET STRAIN!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+                            LOGV(PB_LogLevel_WARNING, "Resetting strain sensor. 20 consecutive readings discarded.");
+                            strain.power_down();
+                            delay(100);
+                            strain.power_up();
+                            delay(100);
+                            strain.set_offset(0);
+                            strain.tare();
+                            delay(100);
+                            discarded_strain_reading_count = 0;
+                        }
+
                         LOGW("Discarding strain reading, too big difference from last reading.");
                         LOGV(PB_LogLevel_WARNING, "Current raw strain reading: %f", strain_reading_raw);
                         LOGV(PB_LogLevel_WARNING, "Last raw strain reading: %f", last_strain_reading_raw_);
                     }
                     else
                     {
+                        discarded_strain_reading_count = 0;
                         sensors_state.strain.raw_value = strain_filter.addSample(strain_reading_raw);
 
                         // LOGD("Strain raw reading: %f", sensors_state.strain.raw_value);
@@ -261,7 +277,20 @@ void SensorsTask::run()
                         last_strain_check_ms = millis();
                     }
                 }
+
                 do_strain = true;
+            }
+            else
+            {
+                if (do_strain)
+                {
+                    LOGV(PB_LogLevel_DEBUG, "Strain sensor not ready, waiting...");
+                }
+                else
+                {
+
+                    LOGV(PB_LogLevel_DEBUG, "Strain sensor is disabled. (Might be because of factory calib or its powered off because no engagement of knob)");
+                }
             }
         }
 #endif
@@ -442,6 +471,7 @@ void SensorsTask::weightMeasurementCallback()
 void SensorsTask::strainPowerDown()
 {
     LOGV(PB_LogLevel_DEBUG, "Strain sensor power down.");
+    strain_powered = false;
     strain.power_down();
 }
 
@@ -449,8 +479,14 @@ void SensorsTask::strainPowerUp()
 {
     LOGV(PB_LogLevel_DEBUG, "Strain sensor power up.");
     strain.power_up();
+    delay(25);
+    strain.set_offset(0);
+    strain.tare();
+    delay(100);
+    last_strain_reading_raw_ = strain.get_units(10);
+    LOGE("Strain value after power up: %f", last_strain_reading_raw_);
+    strain_powered = true;
     // delay(100);
-    // strain.tare();
 }
 #endif
 

--- a/firmware/src/sensors/sensors_task.h
+++ b/firmware/src/sensors/sensors_task.h
@@ -39,6 +39,9 @@ private:
     SensorsState sensors_state = {};
     QueueHandle_t sensors_state_queue_;
 
+    bool do_strain = false;
+    bool strain_powered = false;
+
     QueueHandle_t shared_events_queue;
 
     std::vector<QueueHandle_t> state_listeners_;

--- a/firmware/src/sensors/sensors_task.h
+++ b/firmware/src/sensors/sensors_task.h
@@ -29,6 +29,9 @@ public:
     void setSharedEventsQueue(QueueHandle_t shared_event_queue);
     void publishEvent(WiFiEvent event);
 
+    void strainPowerDown();
+    void strainPowerUp();
+
 protected:
     void run();
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -140,6 +140,11 @@ build_flags =
     ; Press weight in grams
     -D PRESS_WEIGHT=250
 
+    ; KNOB ENGAGED TIMEOUT MILISECONDS
+    -D KNOB_ENGAGED_TIMEOUT_NONE_PHYSICAL=8000
+    -D KNOB_ENGAGED_TIMEOUT_PHYSICAL=30000
+
+
 [env:seedlabs_devkit_inverted_display]
 build_flags = 
 	${env:seedlabs_devkit.build_flags}


### PR DESCRIPTION
Should fix issues regarding strain drift and or issues of strain not working after awhile.
If not fix. Greatly reduce at least, might be hardware related issue not completely fixable by software.

Also found some issues, after a while maybe 12-24h knob slows down causing strain to lag behind? and also screen updates when rotating knob.

Updates screen dimming and adds two parameters in platformio.ini file for setting the timeouts, one for actual physical interaction with device now set to 30s timeout and on for if and when  only proximity is detected but no physical interaction this timeout is set to 8s for now.