### PR TITLE
Fixed issue with strain being allowed to power off even during calibration...

### DIFF
--- a/firmware/src/sensors/sensors_task.cpp
+++ b/firmware/src/sensors/sensors_task.cpp
@@ -475,7 +475,7 @@ void SensorsTask::weightMeasurementCallback()
 
 bool SensorsTask::powerDownAllowed()
 {
-    // If strain sensor isnt calibrated and dont allow power down.
+    // If strain sensor isnt calibrated dont allow power down.
     if (calibration_scale_ == 1.0f && strain.get_scale() == 1.0f)
     {
         return false;

--- a/firmware/src/sensors/sensors_task.cpp
+++ b/firmware/src/sensors/sensors_task.cpp
@@ -473,9 +473,27 @@ void SensorsTask::weightMeasurementCallback()
     }
 }
 
+bool SensorsTask::powerDownAllowed()
+{
+    // If strain sensor isnt calibrated and dont allow power down.
+    if (calibration_scale_ == 1.0f && strain.get_scale() == 1.0f)
+    {
+        return false;
+    }
+
+    // If calibration or weight measurement is in progress, dont allow power down.
+    if (weight_measurement_step_ != 0 || factory_strain_calibration_step_ != 0)
+    {
+        return false;
+    }
+
+    // Allow power down.
+    return true;
+}
+
 void SensorsTask::strainPowerDown()
 {
-    if ((calibration_scale_ == 1.0f && strain.get_scale() == 1.0f && factory_strain_calibration_step_ == 0) || (weight_measurement_step_ != 0 || factory_strain_calibration_step_ != 0))
+    if (!powerDownAllowed())
     {
         return;
     }

--- a/firmware/src/sensors/sensors_task.cpp
+++ b/firmware/src/sensors/sensors_task.cpp
@@ -343,6 +343,8 @@ void SensorsTask::factoryStrainCalibrationCallback(float calibration_weight)
         factory_strain_calibration_step_ = 1;
         LOGI("Factory strain calibration step 1");
 
+        strainPowerUp();
+
         delay(200);
 
         strain.set_scale();
@@ -447,7 +449,7 @@ void SensorsTask::factoryStrainCalibrationCallback(float calibration_weight)
         LOGD("Verify calibrated weight: %0.0fg", strain.get_units(10));
     }
     LOGI("\nRemove calibration weight.\n");
-    delay(5000);
+    delay(8000);
     LOGI("Factory strain calibration complete!");
     strain.set_offset(0);
     strain.tare();
@@ -473,6 +475,11 @@ void SensorsTask::weightMeasurementCallback()
 
 void SensorsTask::strainPowerDown()
 {
+    if ((calibration_scale_ == 1.0f && strain.get_scale() == 1.0f && factory_strain_calibration_step_ == 0) || (weight_measurement_step_ != 0 || factory_strain_calibration_step_ != 0))
+    {
+        return;
+    }
+
     if (strain.wait_ready_timeout(10)) // Make sure sensor is on before powering down.
     {
         LOGV(PB_LogLevel_DEBUG, "Strain sensor power down.");

--- a/firmware/src/sensors/sensors_task.h
+++ b/firmware/src/sensors/sensors_task.h
@@ -29,6 +29,8 @@ public:
     void setSharedEventsQueue(QueueHandle_t shared_event_queue);
     void publishEvent(WiFiEvent event);
 
+    bool powerDownAllowed();
+
     void strainPowerDown();
     void strainPowerUp();
 


### PR DESCRIPTION
Fixed power down of strain  that could happen during strain calibration, upped time to remove weight after calibration to 8s from 5s.